### PR TITLE
Implement JWT logout and token invalidation support

### DIFF
--- a/src/main/java/com/learn/IdentityService/configuration/CustomJwtDecoder.java
+++ b/src/main/java/com/learn/IdentityService/configuration/CustomJwtDecoder.java
@@ -1,0 +1,50 @@
+package com.learn.IdentityService.configuration;
+
+import java.text.ParseException;
+import java.util.Objects;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.learn.IdentityService.dto.request.IntrospectRequest;
+import com.learn.IdentityService.service.AuthenticationService;
+import com.nimbusds.jose.JOSEException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jose.jws.MacAlgorithm;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomJwtDecoder implements JwtDecoder {
+    @Value("${jwt.secret}")
+    private String signerKey;
+
+    @Autowired
+    private AuthenticationService authenticationService;
+
+    private NimbusJwtDecoder nimbusJwtDecoder = null;
+
+    @Override
+    public Jwt decode(String token) throws JwtException {
+
+        try {
+            var response = authenticationService.introspect(
+                    IntrospectRequest.builder().token(token).build());
+
+            if (!response.isValid()) throw new JwtException("Token invalid");
+        } catch (JOSEException | ParseException e) {
+            throw new JwtException(e.getMessage());
+        }
+
+        if (Objects.isNull(nimbusJwtDecoder)) {
+            SecretKeySpec secretKeySpec = new SecretKeySpec(signerKey.getBytes(), "HS512");
+            nimbusJwtDecoder = NimbusJwtDecoder.withSecretKey(secretKeySpec)
+                    .macAlgorithm(MacAlgorithm.HS512)
+                    .build();
+        }
+
+        return nimbusJwtDecoder.decode(token);
+    }
+}

--- a/src/main/java/com/learn/IdentityService/configuration/SecurityConfig.java
+++ b/src/main/java/com/learn/IdentityService/configuration/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.learn.IdentityService.configuration;
 
 import com.learn.IdentityService.enums.Role;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -28,11 +29,12 @@ public class SecurityConfig {
     private final String[] PUBLIC_ENDPOINTS = {
             "/users",
             "/auth/token",
-            "/auth/introspect"
+            "/auth/introspect",
+            "/auth/logout"
     };
 
-    @Value("${jwt.secret}")
-    String signerKey;
+    @Autowired
+    private CustomJwtDecoder customJwtDecoder;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
@@ -43,7 +45,7 @@ public class SecurityConfig {
 
         httpSecurity.oauth2ResourceServer(oauth2 ->
                 oauth2.jwt(jwtConfigurer ->
-                        jwtConfigurer.decoder(jwtDecoder())
+                        jwtConfigurer.decoder(customJwtDecoder)
                                 .jwtAuthenticationConverter(jwtAuthenticationConverter()))
                                 .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
         );
@@ -62,14 +64,6 @@ public class SecurityConfig {
         return jwtAuthenticationConverter;
     }
 
-    @Bean
-    JwtDecoder jwtDecoder() {
-        SecretKeySpec secretKeySpec = new SecretKeySpec(signerKey.getBytes(), "HS512");
-        return NimbusJwtDecoder
-                .withSecretKey(secretKeySpec)
-                .macAlgorithm(MacAlgorithm.HS512)
-                .build();
-    }
 
     @Bean
     PasswordEncoder passwordEncoder() {

--- a/src/main/java/com/learn/IdentityService/controller/AuthenticationController.java
+++ b/src/main/java/com/learn/IdentityService/controller/AuthenticationController.java
@@ -1,6 +1,7 @@
 package com.learn.IdentityService.controller;
 
 import com.learn.IdentityService.dto.request.IntrospectRequest;
+import com.learn.IdentityService.dto.request.LogoutRequest;
 import com.learn.IdentityService.dto.response.IntrospectResponse;
 import com.nimbusds.jose.JOSEException;
 
@@ -31,17 +32,19 @@ public class AuthenticationController {
     @PostMapping("/token")
     ApiResponse<AuthenticationResponse> authenticate(@RequestBody AuthenticationRequest request) {
         var result = authenticationService.authenticate(request);
-        return ApiResponse.<AuthenticationResponse>builder()
-                .result(result)
-                .build();
+        return ApiResponse.<AuthenticationResponse>builder().result(result).build();
     }
 
     @PostMapping("/introspect")
     ApiResponse<IntrospectResponse> authenticate(@RequestBody IntrospectRequest request)
-    throws JOSEException, ParseException {
+            throws ParseException, JOSEException {
         var result = authenticationService.introspect(request);
-        return ApiResponse.<IntrospectResponse>builder()
-                .result(result)
-                .build();
+        return ApiResponse.<IntrospectResponse>builder().result(result).build();
+    }
+
+    @PostMapping("/logout")
+    ApiResponse<Void> logout(@RequestBody LogoutRequest request) throws ParseException, JOSEException {
+        authenticationService.logout(request);
+        return ApiResponse.<Void>builder().build();
     }
 }

--- a/src/main/java/com/learn/IdentityService/dto/request/LogoutRequest.java
+++ b/src/main/java/com/learn/IdentityService/dto/request/LogoutRequest.java
@@ -1,0 +1,16 @@
+package com.learn.IdentityService.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+public class LogoutRequest {
+    String token;
+}

--- a/src/main/java/com/learn/IdentityService/entity/InvalidatedToken.java
+++ b/src/main/java/com/learn/IdentityService/entity/InvalidatedToken.java
@@ -1,0 +1,21 @@
+package com.learn.IdentityService.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+import java.util.Date;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@Entity
+public class InvalidatedToken {
+    @Id
+    String id;
+    Date expiryTime;
+}

--- a/src/main/java/com/learn/IdentityService/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/learn/IdentityService/exception/GlobalExceptionHandler.java
@@ -20,6 +20,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(value = Exception.class)
     ResponseEntity<ApiResponse<Object>> handlingRuntimeException(AppException exception) {
+        
         // Log the actual exception for debugging
         ErrorCode errorCode = exception.getErrorCode();
         ApiResponse<Object> apiResponse = new ApiResponse<>();

--- a/src/main/java/com/learn/IdentityService/repository/InvalidatedTokenRepository.java
+++ b/src/main/java/com/learn/IdentityService/repository/InvalidatedTokenRepository.java
@@ -1,0 +1,8 @@
+package com.learn.IdentityService.repository;
+
+import com.learn.IdentityService.entity.InvalidatedToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InvalidatedTokenRepository extends JpaRepository<InvalidatedToken, String> {
+
+}


### PR DESCRIPTION
Added logout endpoint and logic to invalidate JWTs by storing their IDs in a new InvalidatedToken entity and repository. Introduced CustomJwtDecoder to check token validity and invalidation. Updated AuthenticationService, SecurityConfig, and AuthenticationController to support logout and token invalidation. Added LogoutRequest DTO and related persistence classes.