### PR TITLE
Add JWT refresh token endpoint and logic

### DIFF
--- a/src/main/java/com/learn/IdentityService/configuration/SecurityConfig.java
+++ b/src/main/java/com/learn/IdentityService/configuration/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
             "/users",
             "/auth/token",
             "/auth/introspect",
-            "/auth/logout"
+            "/auth/logout",
+            "/auth/refresh",
     };
 
     @Autowired

--- a/src/main/java/com/learn/IdentityService/controller/AuthenticationController.java
+++ b/src/main/java/com/learn/IdentityService/controller/AuthenticationController.java
@@ -1,7 +1,6 @@
 package com.learn.IdentityService.controller;
 
-import com.learn.IdentityService.dto.request.IntrospectRequest;
-import com.learn.IdentityService.dto.request.LogoutRequest;
+import com.learn.IdentityService.dto.request.*;
 import com.learn.IdentityService.dto.response.IntrospectResponse;
 import com.nimbusds.jose.JOSEException;
 
@@ -17,8 +16,6 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.learn.IdentityService.service.AuthenticationService;
-import com.learn.IdentityService.dto.request.ApiResponse;
-import com.learn.IdentityService.dto.request.AuthenticationRequest;
 import com.learn.IdentityService.dto.response.AuthenticationResponse;
 
 @RestController
@@ -40,6 +37,13 @@ public class AuthenticationController {
             throws ParseException, JOSEException {
         var result = authenticationService.introspect(request);
         return ApiResponse.<IntrospectResponse>builder().result(result).build();
+    }
+
+    @PostMapping("/refresh")
+    ApiResponse<AuthenticationResponse> refresh(@RequestBody RefreshRequest request)
+            throws ParseException, JOSEException {
+        var result = authenticationService.refreshToken(request);
+        return ApiResponse.<AuthenticationResponse>builder().result(result).build();
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/learn/IdentityService/dto/request/RefreshRequest.java
+++ b/src/main/java/com/learn/IdentityService/dto/request/RefreshRequest.java
@@ -1,0 +1,16 @@
+package com.learn.IdentityService.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@FieldDefaults(level = lombok.AccessLevel.PRIVATE)
+public class RefreshRequest {
+    String token;
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,3 +15,5 @@ spring:
 
 jwt:
     secret: "CLliqQX0S3JzqrR4bz2ywiWnAtBu/rrGu+WGH7r6kn7JgMor49mwXS7goDLK35Un"
+    valid-duration: 3600 #in seconds
+    refresh-duration: 360000 #in seconds


### PR DESCRIPTION
Introduced a new /auth/refresh endpoint and RefreshRequest DTO to support JWT token refreshing. Updated AuthenticationService to handle refresh logic, including token invalidation and configurable token durations via application.yaml. SecurityConfig was updated to permit access to the new endpoint.